### PR TITLE
Add support for element attributes, numbering formats

### DIFF
--- a/mammoth/documents.py
+++ b/mammoth/documents.py
@@ -57,7 +57,7 @@ class LineBreak(Element):
 @cobble.data
 class Tab(Element):
     pass
-    
+
 
 @cobble.visitable
 class Image(Element):
@@ -107,15 +107,17 @@ class Bookmark(Element):
     name = cobble.field()
 
 bookmark = Bookmark
-    
+
 
 table = Table
 table_row = TableRow
 table_cell = TableCell
 line_break = LineBreak
 
+
 def numbering_level(level_index, is_ordered, num_fmt):
     return _NumberingLevel(str(level_index), bool(is_ordered), str(num_fmt))
+
 
 @cobble.data
 class _NumberingLevel(object):
@@ -136,13 +138,13 @@ note = Note
 class Notes(object):
     def __init__(self, notes):
         self._notes = notes
-    
+
     def find_note(self, note_type, note_id):
         return self._notes[(note_type, note_id)]
-    
+
     def resolve(self, reference):
         return self.find_note(reference.note_type, reference.note_id)
-    
+
     def __eq__(self, other):
         return isinstance(other, Notes) and self._notes == other._notes
 
@@ -154,7 +156,7 @@ def notes(notes_list):
         (_note_key(note), note)
         for note in notes_list
     ))
-    
+
 def _note_key(note):
     return (note.note_type, note.note_id)
 

--- a/mammoth/docx/numbering_xml.py
+++ b/mammoth/docx/numbering_xml.py
@@ -50,7 +50,7 @@ def _read_num(element, abstract_nums):
 class Numbering(object):
     def __init__(self, nums):
         self._nums = nums
-    
+
     def find_level(self, num_id, level):
         num = self._nums.get(num_id)
         if num is None:

--- a/mammoth/html_paths.py
+++ b/mammoth/html_paths.py
@@ -7,28 +7,31 @@ def path(elements):
     return HtmlPath(elements)
 
 
-def element(names, class_names=None, fresh=None):
+def element(names, class_names=None, extra_attributes=None, fresh=None):
     if class_names is None:
         class_names = []
+    if extra_attributes is None:
+        extra_attributes = {}
     if fresh is None:
         fresh = False
-    return HtmlPathElement(names, class_names, fresh)
+    return HtmlPathElement(names, class_names, extra_attributes, fresh)
 
 
 @cobble.data
 class HtmlPath(object):
     elements = cobble.field()
-    
+
     def wrap(self, nodes):
         for element in reversed(self.elements):
             nodes = element.wrap(nodes)
-        
+
         return nodes
 
 @cobble.data
 class HtmlPathElement(object):
     names = cobble.field()
     class_names = cobble.field()
+    extra_attributes = cobble.field()
     fresh = cobble.field()
 
     def wrap(self, nodes):
@@ -36,6 +39,8 @@ class HtmlPathElement(object):
             attributes = {"class": " ".join(self.class_names)}
         else:
             attributes = {}
+        if self.extra_attributes:
+            attributes.update(extra_attributes)
         element = html.element(
             self.names,
             attributes,

--- a/mammoth/options.py
+++ b/mammoth/options.py
@@ -5,7 +5,7 @@ def read_options(options):
     custom_style_map_result = _read_style_map(options.get("style_map") or "")
     include_default_style_map = options.get("include_default_style_map", True)
     options["ignore_empty_paragraphs"] = options.get("ignore_empty_paragraphs", True)
-    
+
     options["style_map"] = custom_style_map_result.value + \
         (_default_style_map if include_default_style_map else [])
     return custom_style_map_result.map(lambda _: options)
@@ -15,7 +15,7 @@ def _read_style_map(style_text):
     lines = filter(None, map(_get_line, style_text.split("\n")))
     return results.combine(lists.map(style_reader.read_style, lines)) \
         .map(lambda style_mappings: lists.filter(None, style_mappings))
-    
+
 
 def _get_line(line):
     line = line.strip()
@@ -46,7 +46,7 @@ p[style-name='footnote text'] => p
 r[style-name='footnote reference'] =>
 p[style-name='endnote text'] => p
 r[style-name='endnote reference'] =>
-        
+
 # LibreOffice
 p[style-name='Footnote'] => p
 r[style-name='Footnote anchor'] =>
@@ -64,11 +64,17 @@ p:ordered-list(3) => ul|ol > li > ul|ol > li > ol > li:fresh
 p:ordered-list(4) => ul|ol > li > ul|ol > li > ul|ol > li > ol > li:fresh
 p:ordered-list(5) => ul|ol > li > ul|ol > li > ul|ol > li > ul|ol > li > ol > li:fresh
 
+# pattern for different numbering formats
+p:ordered-list(1,decimal) => ol > li{type=1}:fresh
+p:ordered-list(1,letter) => ol > li{type=a}:fresh
+p:ordered-list(1,roman) => ol > li{type=i}:fresh
+p:ordered-list(1,upperLetter) => ol > li{type=A}:fresh
+p:ordered-list(1,upperRoman) => ol > li{type=I}:fresh
+
 r[style-name='Hyperlink'] =>
 
 p[style-name='Normal'] => p:fresh
 """)
-
 
 assert not _default_style_map_result.messages
 _default_style_map = _default_style_map_result.value

--- a/mammoth/style_reader/document_matcher_reader.py
+++ b/mammoth/style_reader/document_matcher_reader.py
@@ -22,14 +22,14 @@ def read_document_matcher_node(root_node):
         return document_matchers.underline
     elif element_node.expr_name == "strikethrough":
         return document_matchers.strikethrough
-    
+
 
 def _read_paragraph_node(paragraph_node):
     style_id = _read_style_id_node(paragraph_node.children[1])
     style_name = _read_style_name_node(paragraph_node.children[2])
     numbering = _read_list_node(paragraph_node.children[3])
     return document_matchers.paragraph(style_id=style_id, style_name=style_name, numbering=numbering)
-    
+
 
 def _read_run_node(run_node):
     style_id = _read_style_id_node(run_node.children[1])
@@ -53,9 +53,15 @@ def _read_style_name_node(style_name_node):
 
 def _read_list_node(list_node):
     if list_node.children:
+        num_fmt_node = list_node.children[0].children[4]
+        if num_fmt_node.text:
+            num_fmt = num_fmt_node.children[0].children[1].text
+        else:
+            num_fmt = None
         return documents.numbering_level(
             int(list_node.children[0].children[3].text) - 1,
             is_ordered=list_node.children[0].children[1].text == "ordered-list",
+            num_fmt=num_fmt
         )
     else:
         return None
@@ -83,9 +89,12 @@ style_name_specifier = "[style-name='" style_name "']"
 
 style_name = ~"[^']+"
 
-list = ":" list_type "(" ~"[0-9]+" ")"
+list = ":" list_type "(" ~"[0-9]+" optional_num_fmt? ")"
+
+optional_num_fmt = "," num_fmt
+
+num_fmt = "decimal" / "letter" / "roman" / "upperLetter" / "upperRoman"
 
 list_type = "ordered-list" / "unordered-list"
 """
 _grammar = Grammar(grammar_text)
-

--- a/tests/style_reader_tests.py
+++ b/tests/style_reader_tests.py
@@ -20,7 +20,7 @@ class ReadHtmlPathTests(object):
             read_html_path("p")
         )
 
-    
+
     @istest
     def can_read_choice_of_two_elements(self):
         assert_equal(
@@ -28,7 +28,7 @@ class ReadHtmlPathTests(object):
             read_html_path("ul|ol")
         )
 
-    
+
     @istest
     def can_read_choice_of_three_elements(self):
         assert_equal(
@@ -36,7 +36,7 @@ class ReadHtmlPathTests(object):
             read_html_path("ul|ol|p")
         )
 
-    
+
     @istest
     def can_read_nested_elements(self):
         assert_equal(
@@ -44,7 +44,7 @@ class ReadHtmlPathTests(object):
             read_html_path("ul > li")
         )
 
-    
+
     @istest
     def can_read_class_on_element(self):
         assert_equal(
@@ -52,7 +52,7 @@ class ReadHtmlPathTests(object):
             read_html_path("p.tip")
         )
 
-    
+
     @istest
     def can_read_multiple_classes_on_element(self):
         assert_equal(
@@ -60,12 +60,43 @@ class ReadHtmlPathTests(object):
             read_html_path("p.tip.help")
         )
 
-    
+
     @istest
     def can_read_when_element_must_be_fresh(self):
         assert_equal(
             html_paths.path([html_paths.element(["p"], fresh=True)]),
             read_html_path("p:fresh")
+        )
+
+    @istest
+    def can_read_attribute_on_element(self):
+        assert_equal(
+            html_paths.path([html_paths.element(["li"], class_names=[],
+                                                extra_attributes={'type': '1'})]),
+            read_html_path("li{type=1}")
+        )
+
+    @istest
+    def can_read_multiple_attributes_on_element(self):
+        assert_equal(
+            html_paths.path([
+                html_paths.element(["li"], class_names=[],
+                                   extra_attributes={'id': 'one',
+                                                     'type': 'i',
+                                                     'name': 'test'})]),
+            read_html_path("li{id=one,type=i,name=test}")
+        )
+
+    @istest
+    def can_read_all_the_things_on_element(self):
+        assert_equal(
+            html_paths.path([
+                html_paths.element(["p"], class_names=["tip", "top"],
+                                   extra_attributes={'id': 'para',
+                                                     'data': 'ordered',
+                                                     'name': 'test'},
+                                   fresh=True)]),
+            read_html_path("p.tip.top{id=para,data=ordered,name=test}:fresh")
         )
 
 
@@ -77,56 +108,62 @@ class ReadDocumentMatcherTests(object):
             document_matchers.paragraph(),
             read_document_matcher("p")
         )
-    
-    
+
+
     @istest
     def reads_paragraph_with_style_id(self):
         assert_equal(
             document_matchers.paragraph(style_id="Heading1"),
             read_document_matcher("p.Heading1")
         )
-    
-    
+
+
     @istest
     def reads_paragraph_with_style_name(self):
         assert_equal(
             document_matchers.paragraph(style_name="Heading 1"),
             read_document_matcher("p[style-name='Heading 1']")
         )
-    
-    
+
+
     @istest
     def reads_paragraph_ordered_list(self):
         assert_equal(
             document_matchers.paragraph(numbering=documents.numbering_level(1, is_ordered=True)),
             read_document_matcher("p:ordered-list(2)")
         )
-    
-    
+
+
     @istest
     def reads_paragraph_unordered_list(self):
         assert_equal(
             document_matchers.paragraph(numbering=documents.numbering_level(1, is_ordered=False)),
             read_document_matcher("p:unordered-list(2)")
         )
-    
-    
+
+    @istest
+    def reads_paragraph_ordered_list_with_num_fmt(self):
+        assert_equal(
+            document_matchers.paragraph(numbering=documents.numbering_level(0, is_ordered=True, num_fmt='decimal')),
+            read_document_matcher("p:ordered-list(1,decimal)")
+        )
+
     @istest
     def reads_plain_run(self):
         assert_equal(
             document_matchers.run(),
             read_document_matcher("r")
         )
-    
-    
+
+
     @istest
     def reads_run_with_style_id(self):
         assert_equal(
             document_matchers.run(style_id="Emphasis"),
             read_document_matcher("r.Emphasis")
         )
-    
-    
+
+
     @istest
     def reads_run_with_style_name(self):
         assert_equal(


### PR DESCRIPTION
This adds support in the style grammar (and the corresponding reader
code) for arbitrary attributes to be added to an output element, using
the format `p{a=b,c=d}` where `a` and `c` are attribute names and `b`
and `d` are attribute values. It also adds a specific use-case in the
form of supporting different formats for numbered lists (e.g. letters,
Roman numerals).
